### PR TITLE
(Footer) Page Numbering Design Properties

### DIFF
--- a/design/design.css
+++ b/design/design.css
@@ -57,7 +57,7 @@ form {
 #selectIcons {
     background-image: url('../images/select-icons-new.png');
 }
-#selectFont {
+#selectFonts {
     background-image: url('../images/select-font-new.png');
 }
 
@@ -88,7 +88,7 @@ form {
     display: none;
     position: absolute;
     top: 75px;
-    width: 45%;
+    width: 44.5%;
     height: 298px;
     color: white;
     background-color: #0b4f74;
@@ -173,7 +173,7 @@ form {
     height: 64px;
 }
 
-#accordionBody {
+#accordionHeader, #accordionFooter, #accordionBody, #accordionMenus, #accordionIcons, #accordionFonts {
 	overflow-y: auto;
 }
 .colourBox {

--- a/design/design.js
+++ b/design/design.js
@@ -81,6 +81,9 @@
             pageNumBorder : {
                 colour: '#000000'
             },
+            pageNumTextColour : {
+                colour: '#ffffff'
+            },
             bodyBackgroundColour : {
                 colour: '#ffffff'
             },
@@ -178,6 +181,7 @@
         css += '#x_pageNo {\n';
         css += '\t' + 'background-color: ' + styles.pageNumBackground.colour + ';\n';
         css += '\t' + 'border: 1px solid ' + styles.pageNumBorder.colour + ';\n';
+        css += '\t' + 'color: ' + styles.pageNumTextColour.colour + ';\n';
         css += '}\n\n';
 
         css += '/* BODY BACKGROUND */\n\n';
@@ -554,3 +558,13 @@
     updateCSS();
     
 }());
+
+//Scroll to the very bottom of the overlapped Design Accordions
+function scrollBottom(clicked_id) {
+
+    //Find the parent div we are in, e.g. accordionFooter and add a # symbol to the front of it
+    var selectedAccordion = "#" + clicked_id.parentNode.parentNode.id;
+    console.log("selectedAccordion");
+    //Scroll to the bottom the accordion stack
+    $(selectedAccordion).animate({scrollTop: $(selectedAccordion)[0].scrollHeight}, 2000);
+}

--- a/design/design.js
+++ b/design/design.js
@@ -75,6 +75,9 @@
             footerDotsTexture : {
                 status: 'on'
             },
+            pageNumBackground : {
+                colour: '#000000'
+            },
             bodyBackgroundColour : {
                 colour: '#ffffff'
             },
@@ -165,6 +168,12 @@
         css += '#x_footerBg {\n';
         css += '\t' + 'background-image: ';
         css += (styles.footerDotsTexture.status === 'on') ? 'url("../includes/xerte/modules/xerte/parent_templates/Nottingham/common_html5/dots.png");\n' : 'none;\n';
+        css += '}\n\n';
+
+        css += '/* FOOTER PAGE NUMBERING BOX */\n\n';
+
+        css += '#x_pageNo {\n';
+        css += '\t' + 'background-color: ' + styles.pageNumBackground.colour + ';\n';
         css += '}\n\n';
 
         css += '/* BODY BACKGROUND */\n\n';

--- a/design/design.js
+++ b/design/design.js
@@ -10,14 +10,14 @@
         selectBody = document.getElementById('selectBody'),
         selectMenus = document.getElementById('selectMenus'),
         selectIcons = document.getElementById('selectIcons'),
-        selectFont = document.getElementById('selectFont'),
+        selectFonts = document.getElementById('selectFonts'),
         accordionHelp = document.getElementById('accordionHelp'),
         accordionHeader = document.getElementById('accordionHeader'),
         accordionFooter = document.getElementById('accordionFooter'),
         accordionBody = document.getElementById('accordionBody'),
         accordionMenus = document.getElementById('accordionMenus'),
         accordionIcons = document.getElementById('accordionIcons'),
-        accordionFont = document.getElementById('accordionFont'),
+        accordionFonts = document.getElementById('accordionFonts'),
         colourPicker = document.getElementById('colourPicker'),
         colourPickerClose = document.getElementById('colourPickerClose'),
         colourBoxChoice = document.getElementsByClassName('colourBoxChoice'),
@@ -76,6 +76,9 @@
                 status: 'on'
             },
             pageNumBackground : {
+                colour: '#000000'
+            },
+            pageNumBorder : {
                 colour: '#000000'
             },
             bodyBackgroundColour : {
@@ -174,6 +177,7 @@
 
         css += '#x_pageNo {\n';
         css += '\t' + 'background-color: ' + styles.pageNumBackground.colour + ';\n';
+        css += '\t' + 'border: 1px solid ' + styles.pageNumBorder.colour + ';\n';
         css += '}\n\n';
 
         css += '/* BODY BACKGROUND */\n\n';
@@ -259,21 +263,21 @@
             selectBody.className = 'inactive';
             selectMenus.className = 'inactive';
             selectIcons.className = 'inactive';
-            selectFont.className = 'inactive';
+            selectFonts.className = 'inactive';
         } else {
             accordionHeader.className = 'accordion';
             selectFooter.className = '';
             selectBody.className = '';
             selectMenus.className = '';
             selectIcons.className = '';
-            selectFont.className = '';
+            selectFonts.className = '';
         }
         accordionHelp.className = 'accordion';
         accordionFooter.className = 'accordion';
         accordionBody.className = 'accordion';
         accordionMenus.className = 'accordion';
         accordionIcons.className = 'accordion';
-        accordionFont.className = 'accordion';
+        accordionFonts.className = 'accordion';
         selectHeader.className = '';
         colourPicker.className = '';
         exportWindow.className = '';
@@ -287,21 +291,21 @@
             selectBody.className = 'inactive';
             selectMenus.className = 'inactive';
             selectIcons.className = 'inactive';
-            selectFont.className = 'inactive';
+            selectFonts.className = 'inactive';
         } else {
             accordionFooter.className = 'accordion';
             selectHeader.className = '';
             selectBody.className = '';
             selectMenus.className = '';
             selectIcons.className = '';
-            selectFont.className = '';
+            selectFonts.className = '';
         }
         accordionHelp.className = 'accordion';
         accordionHeader.className = 'accordion';
         accordionBody.className = 'accordion';
         accordionMenus.className = 'accordion';
         accordionIcons.className = 'accordion';
-        accordionFont.className = 'accordion';
+        accordionFonts.className = 'accordion';
         selectFooter.className = '';
         colourPicker.className = '';
         exportWindow.className = '';
@@ -315,7 +319,7 @@
             selectFooter.className = 'inactive';
             selectMenus.className = 'inactive';
             selectIcons.className = 'inactive';
-            selectFont.className = 'inactive';
+            selectFonts.className = 'inactive';
         } else {
             accordionHelp.className = 'accordion';
             accordionBody.className = 'accordion';
@@ -323,13 +327,13 @@
             selectFooter.className = '';
             selectMenus.className = '';
             selectIcons.className = '';
-            selectFont.className = '';
+            selectFonts.className = '';
         }
         accordionFooter.className = 'accordion';
         accordionHeader.className = 'accordion';
         accordionMenus.className = 'accordion';
         accordionIcons.className = 'accordion';
-        accordionFont.className = 'accordion';
+        accordionFonts.className = 'accordion';
         selectBody.className = '';
         colourPicker.className = '';
         exportWindow.className = '';
@@ -343,7 +347,7 @@
             selectBody.className = 'inactive';
             selectFooter.className = 'inactive';
             selectIcons.className = 'inactive';
-            selectFont.className = 'inactive';
+            selectFonts.className = 'inactive';
             xhibitXerteMenu.style.display = 'block';
         } else {
             accordionMenus.className = 'accordion';
@@ -351,14 +355,14 @@
             selectBody.className = '';
             selectFooter.className = '';
             selectIcons.className = '';
-            selectFont.className = '';
+            selectFonts.className = '';
         }
         accordionHelp.className = 'accordion';
         accordionFooter.className = 'accordion';
         accordionHeader.className = 'accordion';
         accordionBody.className = 'accordion';
         accordionIcons.className = 'accordion';
-        accordionFont.className = 'accordion';
+        accordionFonts.className = 'accordion';
         selectMenus.className = '';
         colourPicker.className = '';
         exportWindow.className = '';
@@ -371,37 +375,37 @@
             selectFooter.className = 'inactive';
             selectBody.className = 'inactive';
             selectMenus.className = 'inactive';
-            selectFont.className = 'inactive';
+            selectFonts.className = 'inactive';
         } else {
             accordionIcons.className = 'accordion';
             selectHeader.className = '';
             selectFooter.className = '';
             selectBody.className = '';
             selectMenus.className = '';
-            selectFont.className = '';
+            selectFonts.className = '';
         }
         accordionHelp.className = 'accordion';
         accordionFooter.className = 'accordion';
         accordionHeader.className = 'accordion';
         accordionBody.className = 'accordion';
         accordionMenus.className = 'accordion';
-        accordionFont.className = 'accordion';
+        accordionFonts.className = 'accordion';
         selectIcons.className = '';
         colourPicker.className = '';
         exportWindow.className = '';
         xhibitXerteMenu.style.display = 'none';
     });
 
-    selectFont.addEventListener('click', function () {
-        if (accordionFont.className.indexOf('visible') === -1) {
-            accordionFont.className += ' visible';
+    selectFonts.addEventListener('click', function () {
+        if (accordionFonts.className.indexOf('visible') === -1) {
+            accordionFonts.className += ' visible';
             selectHeader.className = 'inactive';
             selectFooter.className = 'inactive';
             selectBody.className = 'inactive';
             selectMenus.className = 'inactive';
             selectIcons.className = 'inactive';
         } else {
-            accordionFont.className = 'accordion';
+            accordionFonts.className = 'accordion';
             selectHeader.className = '';
             selectFooter.className = '';
             selectBody.className = '';
@@ -414,7 +418,7 @@
         accordionBody.className = 'accordion';
         accordionMenus.className = 'accordion';
         accordionIcons.className = 'accordion';
-        selectFont.className = '';
+        selectFonts.className = '';
         colourPicker.className = '';
         exportWindow.className = '';
         xhibitXerteMenu.style.display = 'none';
@@ -431,7 +435,7 @@
             selectBody.className = '';
             selectMenus.className = '';
             selectIcons.className = '';
-            selectFont.className = '';
+            selectFonts.className = '';
             colourPicker.className = '';
         });
     }

--- a/design/index.php
+++ b/design/index.php
@@ -204,6 +204,15 @@
                                 <input type="radio" name="footerDotsTexture" value="off"/> Off
                             </label>
                         </div>
+                        <div id="pageNumBackground" class="element">
+                            Page Number Background Colour
+                            <div class="plusMinus"></div>
+                        </div>
+                        <div id="pageNumBackgroundEdit" class="elementEdit">
+                            <div class="colourBox"></div>
+                            <div class="colourPickerIcon"></div>
+                            <input class="hexBox" type="text" name="pageNumBackground"/>
+                        </div>
                     </div>
                 </div>
 

--- a/design/index.php
+++ b/design/index.php
@@ -82,7 +82,7 @@
                     <div id="selectBody">Body</div>
                     <div id="selectMenus">Menus</div>
                     <div id="selectIcons">Icons</div>
-                    <div id="selectFont">Fonts</div>
+                    <div id="selectFonts">Fonts</div>
                     <div id="exportBtn">Export</div>
 
                 </div>
@@ -212,6 +212,15 @@
                             <div class="colourBox"></div>
                             <div class="colourPickerIcon"></div>
                             <input class="hexBox" type="text" name="pageNumBackground"/>
+                        </div>
+                        <div id="pageNumBorder" class="element">
+                            Page Number Border
+                            <div class="plusMinus"></div>
+                        </div>
+                        <div id="pageNumBorderEdit" class="elementEdit">
+                            <div class="colourBox"></div>
+                            <div class="colourPickerIcon"></div>
+                            <input class="hexBox" type="text" name="pageNumBorder"/>
                         </div>
                     </div>
                 </div>
@@ -345,7 +354,7 @@
                     </div>
                 </div>
 
-               <div id="accordionFont" class="accordion">
+               <div id="accordionFonts" class="accordion">
                     <div class="elementTitle">
                         Fonts
                         <div class="accordionClose"></div>

--- a/design/index.php
+++ b/design/index.php
@@ -8,6 +8,8 @@
     include('../includes/xerte/xerte-head.html');
     ?>
 
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+
     <!-- CSS -->
     <link rel="stylesheet" type="text/css" href="../xhibit.css">
     <link rel="stylesheet" type="text/css" href="design.css">
@@ -213,7 +215,7 @@
                             <div class="colourPickerIcon"></div>
                             <input class="hexBox" type="text" name="pageNumBackground"/>
                         </div>
-                        <div id="pageNumBorder" class="element">
+                        <div id="pageNumBorder" onclick="scrollBottom(this);" class="element">
                             Page Number Border
                             <div class="plusMinus"></div>
                         </div>
@@ -221,6 +223,15 @@
                             <div class="colourBox"></div>
                             <div class="colourPickerIcon"></div>
                             <input class="hexBox" type="text" name="pageNumBorder"/>
+                        </div>
+                        <div id="pageNumTextColour" onclick="scrollBottom(this);" class="element">
+                            Page Number Text Colour
+                            <div class="plusMinus"></div>
+                        </div>
+                        <div id="pageNumTextColourEdit" class="elementEdit">
+                            <div class="colourBox"></div>
+                            <div class="colourPickerIcon"></div>
+                            <input class="hexBox" type="text" name="pageNumTextColour"/>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Added the following design options for the Page Numbering box which appears in the Footer section:

- Background Colour
- Border
- Text Colour

The latter two design elements have a `scrollBottom()` `onclick` function attached to the associated accordions, so when they are selected (on desktop and tablet), the parent div panel is identified and auto scrolls to the bottom to make the collapsed colour picker selector properties clearly visible to the visitor.