### PR TITLE
Fixed Google Fonts Rendering in Safari (iOS) browser

### DIFF
--- a/about/index.php
+++ b/about/index.php
@@ -21,7 +21,7 @@
     <!-- CSS -->
 
     <!-- Fonts -->
-    <link href="https://fonts.googleapis.com/css?family=Montserrat|Open+Sans" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:400,400i,600,800" rel="stylesheet">
     <!-- Fonts -->
 
     <!-- TWITTER -->

--- a/contact/index.php
+++ b/contact/index.php
@@ -16,7 +16,7 @@
     <!-- CSS -->
 
     <!-- Fonts -->
-    <link href="https://fonts.googleapis.com/css?family=Montserrat|Open+Sans" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:400,400i,600,800" rel="stylesheet">
     <!-- Fonts -->
 
 

--- a/design/index.php
+++ b/design/index.php
@@ -23,7 +23,7 @@
     <!-- CSS -->
 
     <!-- Fonts -->
-    <link href="https://fonts.googleapis.com/css?family=Montserrat|Open+Sans" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:400,400i,600,800" rel="stylesheet">
     <!-- Fonts -->
 
      <!-- TWITTER -->

--- a/index.php
+++ b/index.php
@@ -16,7 +16,7 @@
     <!-- CSS -->
 
     <!-- Fonts -->
-    <link href="https://fonts.googleapis.com/css?family=Montserrat|Open+Sans" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:400,400i,600,800" rel="stylesheet">
     <!-- Fonts -->
 
     <!-- TWITTER -->

--- a/xhibit.css
+++ b/xhibit.css
@@ -35,6 +35,7 @@ body {
     font-size: 3em;
     text-align: center;
     border-bottom: none !important;
+    font-weight: 600;
 }
 
 .index #intro h2 {
@@ -167,6 +168,7 @@ header a:hover, footer a:hover {
     color:#504e4e;
     font-family: 'Montserrat', sans-serif;
     font-size: 1.5em;
+    font-weight: 600;
 }
 
 hr {

--- a/xhibition/index.php
+++ b/xhibition/index.php
@@ -16,7 +16,7 @@
     <!-- CSS -->
 
     <!-- Fonts -->
-    <link href="https://fonts.googleapis.com/css?family=Montserrat|Open+Sans" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:400,400i,600,800" rel="stylesheet">
     <!-- Fonts -->
 
     <!-- TWITTER -->


### PR DESCRIPTION
Google Fonts were rendering poorly in Safari (iOS) due to the `font-weight` classes (400, 900 etc.) not being included in the `<head>` call. This has now been fixed.